### PR TITLE
Fix wrong accidental-value

### DIFF
--- a/xmlFiles/01e-Pitches-EditorialCautionaryAccidentals.xml
+++ b/xmlFiles/01e-Pitches-EditorialCautionaryAccidentals.xml
@@ -139,7 +139,7 @@
         <duration>1</duration>
         <voice>1</voice>
         <type>quarter</type>
-        <accidental>double-flat</accidental>
+        <accidental>flat-flat</accidental>
       </note>
       <note>
         <pitch>
@@ -150,7 +150,7 @@
         <duration>1</duration>
         <voice>1</voice>
         <type>quarter</type>
-        <accidental editorial="yes">double-flat</accidental>
+        <accidental editorial="yes">flat-flat</accidental>
       </note>
       <note>
         <pitch>
@@ -161,7 +161,7 @@
         <duration>1</duration>
         <voice>1</voice>
         <type>quarter</type>
-        <accidental cautionary="yes">double-flat</accidental>
+        <accidental cautionary="yes">flat-flat</accidental>
       </note>
       <note>
         <pitch>
@@ -172,7 +172,7 @@
         <duration>1</duration>
         <voice>1</voice>
         <type>quarter</type>
-        <accidental editorial="yes" cautionary="yes">double-flat</accidental>
+        <accidental editorial="yes" cautionary="yes">flat-flat</accidental>
       </note>
     </measure>
     <!--=======================================================-->


### PR DESCRIPTION
Fixes an encoding error by using the allowed value from [accidental-value data type](https://www.w3.org/2021/06/musicxml40/musicxml-reference/data-types/accidental-value/).