### PR TITLE
Correct transposition error in test description

### DIFF
--- a/xmlFiles/72c-TransposingInstruments-Change.xml
+++ b/xmlFiles/72c-TransposingInstruments-Change.xml
@@ -9,7 +9,7 @@
           (Clarinet in Bb). The displayed instrument name should also be updated.
 
           The whole piece is in Bb major (sounding), so first the key signature
-          should be one flat, after the change it should have no accidentals.
+          should be one sharp, after the change it should have no accidentals.
       </miscellaneous-field>
     </miscellaneous>
   </identification>


### PR DESCRIPTION
Clarinet in E-flat transposes up by minor third. In concert key of B-flat major, it reads in G major.